### PR TITLE
Replaces it with the updated list-compatible syntax

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -30,7 +30,7 @@ module "acm" {
   process_domain_validation_options = var.process_domain_validation_options
   ttl                               = 300
   subject_alternative_names         = local.all_sans
-  zone_id                           = join("", data.aws_route53_zone.default.*.zone_id)
+  zone_id                           = join("", data.aws_route53_zone.default[*].zone_id)
 
   context = module.this.context
 }


### PR DESCRIPTION
## what
* Replace the legacy "attribute-only" splat expressions which use the sequence .* with the newer expression[*]


## why
Earlier versions of the Terraform language had a slightly different version of splat expressions, which Terraform continues to support for backward compatibility. This older variant is less useful than the modern form described above, and so Hashicorp recommends against using it in new configurations.

## references
* https://developer.hashicorp.com/terraform/language/expressions/splat#legacy-attribute-only-splat-expressions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
	- Updated Terraform configuration syntax for list handling for improved clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->