### PR TITLE
chore(deps): upgrade remote-state module to 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,9 @@ components:
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_acm"></a> [acm](#module\_acm) | cloudposse/acm-request-certificate/aws | 0.18.1 |
-| <a name="module_dns_delegated"></a> [dns\_delegated](#module\_dns\_delegated) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
+| <a name="module_dns_delegated"></a> [dns\_delegated](#module\_dns\_delegated) | cloudposse/stack-config/yaml//modules/remote-state | 2.0.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
-| <a name="module_private_ca"></a> [private\_ca](#module\_private\_ca) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
+| <a name="module_private_ca"></a> [private\_ca](#module\_private\_ca) | cloudposse/stack-config/yaml//modules/remote-state | 2.0.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources

--- a/src/README.md
+++ b/src/README.md
@@ -88,9 +88,9 @@ components:
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_acm"></a> [acm](#module\_acm) | cloudposse/acm-request-certificate/aws | 0.18.1 |
-| <a name="module_dns_delegated"></a> [dns\_delegated](#module\_dns\_delegated) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
+| <a name="module_dns_delegated"></a> [dns\_delegated](#module\_dns\_delegated) | cloudposse/stack-config/yaml//modules/remote-state | 2.0.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
-| <a name="module_private_ca"></a> [private\_ca](#module\_private\_ca) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
+| <a name="module_private_ca"></a> [private\_ca](#module\_private\_ca) | cloudposse/stack-config/yaml//modules/remote-state | 2.0.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -1,6 +1,6 @@
 module "private_ca" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
+  version = "2.0.0"
 
   count = local.private_ca_enabled ? 1 : 0
 
@@ -13,7 +13,7 @@ module "private_ca" {
 
 module "dns_delegated" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
+  version = "2.0.0"
 
   component   = var.dns_delegated_component_name
   stage       = var.dns_delegated_stage_name

--- a/test/fixtures/vendor.yaml
+++ b/test/fixtures/vendor.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   sources:
     - component: "account-map"
-      source: github.com/cloudposse/terraform-aws-components.git//modules/account-map?ref={{.Version}}
-      version: 1.520.0
+      source: github.com/cloudposse-terraform-components/aws-account-map.git//src?ref={{.Version}}
+      version: v1.537.2
       targets:
         - "components/terraform/account-map"
       included_paths:
@@ -19,7 +19,7 @@ spec:
 
     - component: "dns-primary"
       source: github.com/cloudposse-terraform-components/aws-dns-primary.git//src?ref={{.Version}}
-      version: v1.534.0
+      version: v1.537.0
       targets:
         - "components/terraform/dns-primary"
       included_paths:
@@ -31,7 +31,7 @@ spec:
 
     - component: "dns-delegated"
       source: github.com/cloudposse-terraform-components/aws-dns-delegated.git//src?ref={{.Version}}
-      version: v1.535.1
+      version: v1.537.1
       targets:
         - "components/terraform/dns-delegated"
       included_paths:


### PR DESCRIPTION
## Summary

- Upgrade `cloudposse/stack-config/yaml//modules/remote-state` from 1.8.0 to 2.0.0 in both `private_ca` and `dns_delegated` modules.
- Migrate test fixture `account-map` vendor source from the monorepo (`terraform-aws-components`) to the standalone repo (`aws-account-map`) at v1.537.2, which includes remote-state v2.
- Bump test fixture vendor versions for `dns-primary` (v1.537.0) and `dns-delegated` (v1.537.1) to releases that already include remote-state v2.

## Test plan

- [ ] Verify `terraform init` succeeds with the new remote-state module version
- [ ] Verify `atmos vendor pull` succeeds with updated vendor.yaml sources and versions
- [ ] Run existing test suite to confirm no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Terraform module dependency versions from 1.8.0 to 2.0.0 for remote-state modules.
  * Updated component versions for account-map, dns-primary, and dns-delegated in test fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->